### PR TITLE
Add plantuml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:3.2
+WORKDIR /app
+
+COPY _themes/jekyll-theme-legumeinfo/jekyll-theme-legumeinfo.gemspec \
+     _themes/jekyll-theme-legumeinfo/jekyll-theme-legumeinfo.gemspec 
+COPY Gemfile* .
+
+RUN bundle install 
+
+ENTRYPOINT ["bundle", "exec", "jekyll", "serve"]
+
+EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:3.2
+RUN apt-get update && apt-get install -y plantuml
 WORKDIR /app
 
 COPY _themes/jekyll-theme-legumeinfo/jekyll-theme-legumeinfo.gemspec \

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "jekyll-theme-legumeinfo", path: "./_themes/jekyll-theme-legumeinfo"
 #gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
+  gem "jekyll-plantuml"
   gem "jekyll-feed", "~> 0.12"
   ## handy way to see if an image exists on the site
   gem 'jekyll_file_exists', :git => 'https://github.com/asperduti/jekyll_file_exists.git'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.2.0"
+gem "jekyll", "~> 4.3.0"
 gem "webrick", "~> 1.7"
 gem "jekyll-theme-legumeinfo", path: "./_themes/jekyll-theme-legumeinfo"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,21 +27,22 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.0)
+    jekyll (4.3.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
-      jekyll-sass-converter (~> 2.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3)
+      kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.4.0)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
-      rouge (~> 3.0)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
-      terminal-table (~> 2.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-datapage-generator (1.4.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
@@ -53,7 +54,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -75,12 +76,14 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (~> 4.2.0)
+  jekyll (~> 4.3.0)
   jekyll-datapage-generator (~> 1.4.0)
   jekyll-feed (~> 0.12)
+  jekyll-plantuml
   jekyll-theme-legumeinfo!
   jekyll_file_exists!
   tzinfo (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     jekyll-datapage-generator (1.4.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-plantuml (1.4.2)
+      jekyll (> 2.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,4 +1,4 @@
 services:
-  jekyll:
-    command: jekyll serve --incremental --config _config.yml,_config.dev.yml
+  serve:
+    command: --incremental --livereload --profile --trace --host 0.0.0.0 --config _config.yml,_config.dev.yml
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,4 +1,4 @@
 services:
   serve:
-    command: --incremental --livereload --profile --trace --host 0.0.0.0 --config _config.yml,_config.dev.yml
+    command: --incremental --profile --trace --host 0.0.0.0 --config _config.yml,_config.dev.yml
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,5 +1,3 @@
 services:
-  jekyll:
-    command: jekyll serve --incremental --config _config.yml,_config.prod.yml
-    restart: always
-
+  serve:
+    command: --incremental --livereload --profile --trace --host 0.0.0.0 --config _config.yml,_config.prod.yml

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,3 +1,3 @@
 services:
   serve:
-    command: --incremental --livereload --profile --trace --host 0.0.0.0 --config _config.yml,_config.prod.yml
+    command: --incremental --profile --trace --host 0.0.0.0 --config _config.yml,_config.prod.yml

--- a/compose.yml
+++ b/compose.yml
@@ -1,23 +1,17 @@
 services:
-  jekyll:
-    image: jekyll/jekyll:4.2.0
+  serve:
+    build: .
+    command: --incremental --livereload --profile --trace --host 0.0.0.0
     volumes:
-      - ./:/srv/jekyll
-      - bundle-cache:/usr/local/bundle
-      - gem-cache:/usr/gem
-## for Windows hosts
-    environment:
-      JEKYLL_UID: ${UID:?please set UID with your userid in the .env file}
-      JEKYLL_GID: ${GID:?please set GID with your groupid in the .env file}
-      VERBOSE: 1
-#     FORCE_POLLING: 1
-#
-# Moved command to compose.dev.yml and compose.prod.yml
-#original: livereload severely delays browser refresh#    command: jekyll serve --incremental --livereload
-    # command: jekyll serve --incremental
+      - ./:/app
     ports:
       - "4000:4000"
       - "35729:35729"
-volumes:
-  bundle-cache:
-  gem-cache:
+
+  build:
+    build: .
+    entrypoint: bundle exec jekyll build --profile --trace
+    volumes:
+      - ./:/app
+    profiles:
+      - build

--- a/compose.yml
+++ b/compose.yml
@@ -1,12 +1,11 @@
 services:
   serve:
     build: .
-    command: --incremental --livereload --profile --trace --host 0.0.0.0
+    command: --incremental --profile --trace --host 0.0.0.0
     volumes:
       - ./:/app
     ports:
       - "4000:4000"
-      - "35729:35729"
 
   build:
     build: .


### PR DESCRIPTION
this updates the container files to be more in line with how the starter site is now doing things, and also (as a separate commit) adds the plantuml plugin/dependency installation. I've tested it on my laptop and it seems to work, but it's probably worth testing in the context of the VM deployment as well. That would probably be easiest if I can take down the jekyll instance on pb-dev currently using 4000 and replace it with one running this version (without clobbering the install in /var/www/jekyll-peanutbase which seems to have some uncommitted changes). Let me know if that's going to cause any problems before I proceed.